### PR TITLE
Apply brand colors

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -43,11 +43,11 @@ const App: React.FC = () => {
   }, []);
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-slate-900 via-slate-800 to-sky-900 text-slate-100">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-brand-green/10 via-white to-brand-green/20 text-brand-black">
       <Header />
       <main className="flex-grow container mx-auto px-4 py-8">
-        <div className="max-w-4xl mx-auto bg-slate-800 shadow-2xl rounded-lg p-6 md:p-10">
-          <p className="mb-6 text-lg text-slate-300">
+        <div className="max-w-4xl mx-auto bg-white shadow-2xl rounded-lg p-6 md:p-10">
+          <p className="mb-6 text-lg text-brand-black/80">
             Deze tool helpt u traditionele leerdoelen om te vormen naar toekomstbestendige, 'AI-proof' versies. 
             Voer de details van uw huidige leerdoel in en de AI genereert suggesties die studenten aanmoedigen 
             AI-tools op een verantwoorde en effectieve manier te gebruiken.

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 
 export const Footer: React.FC = () => {
   return (
-    <footer className="bg-slate-900/80 text-center py-6 mt-auto">
+    <footer className="bg-brand-green/10 text-center py-6 mt-auto">
       <div className="container mx-auto px-4">
-        <p className="text-sm text-slate-400">
+        <p className="text-sm text-brand-black">
           &copy; ${new Date().getFullYear()} AI-Proof Leerdoelen Assistent. Gemaakt met ❤️ en AI.
         </p>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 
 export const Header: React.FC = () => {
   return (
-    <header className="bg-sky-700/50 shadow-lg">
+    <header className="bg-brand-green shadow-lg">
       <div className="container mx-auto px-4 py-6">
-        <h1 className="text-3xl md:text-4xl font-bold text-center text-sky-100 flex items-center justify-center space-x-3">
+        <h1 className="text-3xl md:text-4xl font-bold text-center text-brand-black flex items-center justify-center space-x-3">
           <span role="img" aria-label="graduation cap" className="text-4xl">🎓</span>
           <span>AI-Proof Leerdoelen Assistent</span>
         </h1>

--- a/components/InputForm.tsx
+++ b/components/InputForm.tsx
@@ -33,8 +33,8 @@ export const InputForm: React.FC<InputFormProps> = ({ onSubmit, isLoading }) => 
     });
   };
 
-  const commonInputClass = "w-full p-3 bg-slate-700 border border-slate-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none placeholder-slate-400 text-slate-100 transition-colors";
-  const commonLabelClass = "block mb-2 text-sm font-medium text-sky-200";
+  const commonInputClass = "w-full p-3 bg-white border border-brand-green/40 rounded-md focus:ring-2 focus:ring-brand-green focus:border-brand-green outline-none placeholder-gray-400 text-brand-black transition-colors";
+  const commonLabelClass = "block mb-2 text-sm font-medium text-brand-black";
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -130,7 +130,7 @@ export const InputForm: React.FC<InputFormProps> = ({ onSubmit, isLoading }) => 
       <button
         type="submit"
         disabled={isLoading || !originalObjective.trim()}
-        className="w-full flex items-center justify-center px-6 py-3 bg-sky-600 hover:bg-sky-500 text-white font-semibold rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-opacity-75 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full flex items-center justify-center px-6 py-3 bg-brand-green hover:bg-brand-orange text-white font-semibold rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-brand-orange focus:ring-opacity-75 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isLoading ? (
           <>

--- a/components/ResultsDisplay.tsx
+++ b/components/ResultsDisplay.tsx
@@ -37,15 +37,15 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ objectives }) =>
 
   return (
     <div className="mt-10">
-      <h2 className="text-2xl font-semibold mb-6 text-sky-200">Gegenereerde AI-Proof Leerdoelen:</h2>
+      <h2 className="text-2xl font-semibold mb-6 text-brand-black">Gegenereerde AI-Proof Leerdoelen:</h2>
       <div className="space-y-4">
         {objectives.map((objective) => (
-          <div key={objective.id} className="p-5 bg-slate-700 rounded-lg shadow-lg relative group">
-            <p className="text-slate-200 leading-relaxed mr-12">{objective.text}</p>
+          <div key={objective.id} className="p-5 bg-white border border-brand-green/20 rounded-lg shadow-lg relative group">
+            <p className="text-brand-black leading-relaxed mr-12">{objective.text}</p>
             <button
               onClick={() => handleCopy(objective.text, objective.id)}
               title={copiedId === objective.id ? "Gekopieerd!" : "Kopieer naar klembord"}
-              className="absolute top-3 right-3 p-2 bg-sky-600 hover:bg-sky-500 text-white rounded-full transition-all opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              className="absolute top-3 right-3 p-2 bg-brand-green hover:bg-brand-orange text-white rounded-full transition-all opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-brand-orange"
             >
               {copiedId === objective.id ? <CheckIcon /> : <CopyIcon />}
             </button>

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -5,9 +5,9 @@ export const Spinner: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center space-y-2">
       <div
-        className="animate-spin rounded-full h-12 w-12 border-t-4 border-b-4 border-sky-500"
+        className="animate-spin rounded-full h-12 w-12 border-t-4 border-b-4 border-brand-green"
       ></div>
-      <p className="text-sky-300">Een ogenblik geduld, de AI is aan het werk...</p>
+      <p className="text-brand-black">Een ogenblik geduld, de AI is aan het werk...</p>
     </div>
   );
 };

--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI-Proof Leerdoelen Assistent</title>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              'brand-green': '#64C37D',
+              'brand-orange': '#F7941D',
+              'brand-black': '#1D1D1B'
+            }
+          }
+        }
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎓</text></svg>">
   <script type="importmap">
@@ -17,9 +30,8 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
 </head>
-  <body class="bg-slate-100">
+  <body class="bg-gray-50 text-brand-black">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- integrate brand colors with Tailwind CDN config
- restyle header, footer and spinner components
- adjust form inputs and buttons to brand palette
- update results display layout
- lighten overall theme

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685305c15dd48330b7e2f6f8a4b40099