### PR TITLE
Make PDF upload optional

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [aiProofObjectives, setAiProofObjectives] = useState<ProcessedLearningObjective[]>([]);
+  const [showPdfUploader, setShowPdfUploader] = useState<boolean>(false);
 
   const handleSubmit = useCallback(async (formData: FormData) => {
     setIsLoading(true);
@@ -75,8 +76,15 @@ const App: React.FC = () => {
         </div>
 
         <section className="max-w-4xl mx-auto mt-12">
-          <h2 className="text-2xl font-semibold mb-4 text-primary">Upload PDF</h2>
-          <PdfUploader />
+          <h2 className="text-2xl font-semibold mb-4 text-primary">Upload PDF (optioneel)</h2>
+          <button
+            type="button"
+            onClick={() => setShowPdfUploader(!showPdfUploader)}
+            className="mb-4 px-4 py-2 bg-brand-green text-white rounded-md hover:bg-brand-orange focus:outline-none"
+          >
+            {showPdfUploader ? 'Sluit uploader' : 'Toon uploader'}
+          </button>
+          {showPdfUploader && <PdfUploader />}
         </section>
 
       </main>

--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ This contains everything you need to run your app locally.
 
 ## PDF → Modules met Leeruitkomsten
 
-Upload een PDF (bijv. een kwalificatiedossier) via het onderdeel **Upload PDF**. De tekst wordt uit het document gehaald en naar OpenAI gestuurd om modules met leeruitkomsten te genereren. De resultaten verschijnen in een overzichtelijke grid.
+Het uploaden van een PDF is optioneel. Via **Upload PDF** kunt u desgewenst een kwalificatiedossier aanleveren. De tekst wordt uit het document gehaald en naar OpenAI gestuurd om modules met leeruitkomsten te genereren. De resultaten verschijnen in een overzichtelijke grid.
+Wilt u alleen handmatig leerdoelen invoeren, dan kunt u de PDF-uploader overslaan.


### PR DESCRIPTION
## Summary
- let user toggle PDF uploader via `showPdfUploader` state
- clarify in README that PDF upload isn't required

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685410e86920833082d9a8e13fc5ee15